### PR TITLE
Accept both sigils and curly bracket count.

### DIFF
--- a/syntaxes/elixir-surface.json
+++ b/syntaxes/elixir-surface.json
@@ -20,7 +20,7 @@
     {
       "comment": "Surface heredoc with double quotes",
       "name": "text.html.surface",
-      "begin": "\\s?(~H\"\"\")$",
+      "begin": "\\s?(~[HF]\"\"\")$",
       "beginCaptures": {
         "0": {
           "name": "punctuation.definition.string.begin.elixir"

--- a/syntaxes/surface.json
+++ b/syntaxes/surface.json
@@ -33,14 +33,14 @@
     "surface-interpolation": {
       "patterns": [
         {
-          "begin": "\\{\\{\\{?",
+          "begin": "\\{\\{?\\{?",
           "name": "source.elixir.embedded",
           "beginCaptures": {
             "0": {
               "name": "punctuation.section.embedded.begin.elixir"
             }
           },
-          "end": "\\}\\}\\}?",
+          "end": "\\}\\}?\\}?",
           "endCaptures": {
             "0": {
               "name": "punctuation.section.embedded.end.elixir"


### PR DESCRIPTION
Since people will likely use 0.4.x and 0.5.x for a while I tried to change the regexes to be more forgiving. I copied the two files into my local vscode and everything worked on my transition 0.4->0.4 branch.