### PR TITLE
Modify `blockComment` to use Surface comment syntax

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,6 +1,6 @@
 {
     "comments": {
-        "blockComment": ["<!--", "-->"]
+        "blockComment": ["{!--", "--}"]
     },
     "brackets": [
         ["<", ">"],


### PR DESCRIPTION
Hi, @msaraiva 
this will make VSCode block/line comment function create Surface comments instead of regular HTML comments.